### PR TITLE
Allow message_data to be overriden by a yaml entry (second try)

### DIFF
--- a/esphome/components/datetime/__init__.py
+++ b/esphome/components/datetime/__init__.py
@@ -70,8 +70,6 @@ def _validate_time_present(config):
 
 
 _DATETIME_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
-    web_server.WEBSERVER_SORTING_SCHEMA,
-    cv.MQTT_COMMAND_COMPONENT_SCHEMA,
     cv.Schema(
         {
             cv.Optional(CONF_ON_VALUE): automation.validate_automation(
@@ -81,7 +79,9 @@ _DATETIME_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
             ),
             cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
         }
-    ),
+    )
+    .extend(web_server.WEBSERVER_SORTING_SCHEMA)
+    .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
 ).add_extra(_validate_time_present)
 
 

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -67,8 +67,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -35,7 +35,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
   void connect() override;
   esp_err_t pair();
-  void disconnect();
+  void disconnect() override;
   void release_services();
 
   bool connected() { return this->state_ == espbt::ClientState::ESTABLISHED; }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -11,9 +11,9 @@
 
 #ifdef USE_ESP32
 
+#include <esp_bt_defs.h>
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
-#include <esp_bt_defs.h>
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
@@ -172,6 +172,7 @@ class ESPBTClient : public ESPBTDeviceListener {
                                    esp_ble_gattc_cb_param_t *param) = 0;
   virtual void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) = 0;
   virtual void connect() = 0;
+  virtual void disconnect() = 0;
   virtual void set_state(ClientState st) { this->state_ = st; }
   ClientState state() const { return state_; }
   int app_id;

--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -1,6 +1,9 @@
-import logging
 from dataclasses import dataclass
+import logging
 
+from esphome import pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ANALOG,
     CONF_ID,
@@ -14,10 +17,7 @@ from esphome.const import (
     CONF_PULLUP,
     PLATFORM_ESP8266,
 )
-from esphome import pins
 from esphome.core import CORE, coroutine_with_priority
-import esphome.config_validation as cv
-import esphome.codegen as cg
 
 from . import boards
 from .const import KEY_BOARD, KEY_ESP8266, KEY_PIN_INITIAL_STATES, esp8266_ns
@@ -48,8 +48,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/host/gpio.py
+++ b/esphome/components/host/gpio.py
@@ -1,5 +1,8 @@
 import logging
 
+from esphome import pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
@@ -11,9 +14,6 @@ from esphome.const import (
     CONF_PULLDOWN,
     CONF_PULLUP,
 )
-from esphome import pins
-import esphome.config_validation as cv
-import esphome.codegen as cg
 
 from .const import host_ns
 
@@ -28,8 +28,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/libretiny/gpio.py
+++ b/esphome/components/libretiny/gpio.py
@@ -1,8 +1,8 @@
 import logging
 
+from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome import pins
 from esphome.const import (
     CONF_ANALOG,
     CONF_ID,
@@ -103,8 +103,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/opentherm/const.py
+++ b/esphome/components/opentherm/const.py
@@ -1,5 +1,11 @@
 OPENTHERM = "opentherm"
 
 CONF_OPENTHERM_ID = "opentherm_id"
+CONF_MESSAGE_DATA = "message_data"
 
 SENSOR = "sensor"
+BINARY_SENSOR = "binary_sensor"
+SWITCH = "switch"
+NUMBER = "number"
+OUTPUT = "output"
+INPUT_SENSOR = "input_sensor"

--- a/esphome/components/opentherm/generate.py
+++ b/esphome/components/opentherm/generate.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ID
 from . import const
 from .schema import TSchema
 
+
 opentherm_ns = cg.esphome_ns.namespace("opentherm")
 OpenthermHub = opentherm_ns.class_("OpenthermHub", cg.Component)
 
@@ -130,6 +131,8 @@ async def component_to_code(
         id = conf[CONF_ID]
         if id and id.type == type:
             entity = await create(conf, key, hub)
+            if const.CONF_MESSAGE_DATA in conf:
+                schemas[key].message_data = conf[const.CONF_MESSAGE_DATA]
             cg.add(getattr(hub, f"set_{key}_{component_type.lower()}")(entity))
             keys.append(key)
 

--- a/esphome/components/opentherm/sensor/__init__.py
+++ b/esphome/components/opentherm/sensor/__init__.py
@@ -7,6 +7,18 @@ from .. import const, schema, validate, generate
 DEPENDENCIES = [const.OPENTHERM]
 COMPONENT_TYPE = const.SENSOR
 
+MSG_DATA_TYPES = {
+    "u8_lb",
+    "u8_hb",
+    "s8_lb",
+    "s8_hb",
+    "u8_lb_60",
+    "u8_hb_60",
+    "u16",
+    "s16",
+    "f88",
+}
+
 
 def get_entity_validation_schema(entity: schema.SensorSchema) -> cv.Schema:
     return sensor.sensor_schema(
@@ -17,6 +29,10 @@ def get_entity_validation_schema(entity: schema.SensorSchema) -> cv.Schema:
         or sensor._UNDEF,  # pylint: disable=protected-access
         icon=entity.icon or sensor._UNDEF,  # pylint: disable=protected-access
         state_class=entity.state_class,
+    ).extend(
+        {
+            cv.Optional(const.CONF_MESSAGE_DATA): cv.one_of(*MSG_DATA_TYPES),
+        }
     )
 
 

--- a/esphome/components/rp2040/gpio.py
+++ b/esphome/components/rp2040/gpio.py
@@ -1,6 +1,8 @@
+from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ANALOG,
     CONF_ID,
     CONF_INPUT,
     CONF_INVERTED,
@@ -10,10 +12,8 @@ from esphome.const import (
     CONF_OUTPUT,
     CONF_PULLDOWN,
     CONF_PULLUP,
-    CONF_ANALOG,
 )
 from esphome.core import CORE
-from esphome import pins
 
 from . import boards
 from .const import KEY_BOARD, KEY_RP2040, rp2040_ns
@@ -41,8 +41,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -230,6 +230,7 @@ datetime:
     id: test_date
     type: date
     state_topic: some/topic/date
+    command_topic: test_date/custom_command_topic
     qos: 2
     subscribe_qos: 2
     set_action:

--- a/tests/components/web_server/common_v3.yaml
+++ b/tests/components/web_server/common_v3.yaml
@@ -35,3 +35,11 @@ switch:
     web_server:
       sorting_group_id: sorting_group_2
       sorting_weight: -10
+datetime:
+  - platform: template
+    name: Pick a Date
+    type: datetime
+    optimistic: yes
+    web_server:
+      sorting_group_id: sorting_group_3
+      sorting_weight: -5


### PR DESCRIPTION
This allows users to return data in a different format. e.g.:

      fan_speed:
      name: "Boiler fan speed"
      message_data: "u16" # overrides the default u8_lb_60 message.

# What does this implement/fix?

Useful where devices deviate from the published specification. As an example, we know some boilers return ID35 (fan speed) as a u8_lb, whilst others return a u16.

Addresses one of the points raised in https://github.com/olegtarasov/esphome-opentherm/issues/12