### PR TITLE
Use SOC_RMT_MEM_WORDS_PER_CHANNEL to set RMT_SYMBOL_CAPACITY

### DIFF
--- a/esphome/components/opentherm/opentherm_rmt.h
+++ b/esphome/components/opentherm/opentherm_rmt.h
@@ -38,8 +38,10 @@ class OpenTherm : public OpenThermBase {
   rmt_encoder_handle_t tx_encoder_{};
   // RX buffer for one OpenTherm frame
   // One OpenTherm frame contains 34 Manchester symbols (start + 32 data + stop) and we
-  // allow a little slack for diagnostic captures.
-  static constexpr size_t RMT_SYMBOL_CAPACITY = 40;
+  // allow a little slack for diagnostic captures. Current ESP32 variants have 48 or 64
+  // words per buffer which is more than enough.
+  static constexpr size_t RMT_SYMBOL_CAPACITY = SOC_RMT_MEM_WORDS_PER_CHANNEL;
+  static_assert(RMT_SYMBOL_CAPACITY >= 40, "RMT RX buffer is too small on this ESP32 variant");
   rmt_symbol_word_t rmt_buffer_[RMT_SYMBOL_CAPACITY]{};
   size_t rmt_buffer_symbol_count_{};
   // RMT clock resolution in Hz (1 MHz => 1 tick == 1 us)


### PR DESCRIPTION
On ESP32-S3 mem_block_symbols must be at least 48. Make rmt_symbols configurable and supply default values by variant. Defaults copied from remote_transmitter component.

On ESP32-S3 mem_block_symbols must be at least 48. Set `RMT_SYMBOL_CAPACITY` from `SOC_RMT_MEM_WORDS_PER_CHANNEL` which is the minimum size accepted for TX or RX by the RMT driver; this is either 48 or 64 depending on the ESP32 flavour. Also add a `static_assert()` in case any future flavours go below 40 symbols, which is the smallest number of symbols we'd like to see.

# What does this implement/fix?

https://github.com/olegtarasov/esphome/commit/aecbeb6ef5268e44c59aa6decb96f09776e3c1fb#commitcomment-166559456

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
