### PR TITLE
opentherm: handle timeout during listen

### DIFF
--- a/esphome/components/opentherm/hub.cpp
+++ b/esphome/components/opentherm/hub.cpp
@@ -202,7 +202,12 @@ void OpenthermHub::loop() {
   switch (cur_mode) {
     case OperationMode::WRITE:
     case OperationMode::READ:
+      break;
     case OperationMode::LISTEN:
+      if (this->last_conversation_start_ > 0 && (cur_time - this->last_conversation_start_) > 1150) {
+        ESP_LOGE(TAG, "Hub timeout triggered during receive");
+        this->stop_opentherm_();
+      }
       break;
     case OperationMode::IDLE:
       this->check_timings_(cur_time);


### PR DESCRIPTION
This condition happens relatively frequently if another component hogs the loop time, for example when the wifi component has to reconnect. Occasionally an incoming message will be missed and the OpenTherm component gets stuck listening forever.

This times out of the listening state after a reasonable amount of time has passed.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
