### PR TITLE
opentherm: replace calls to millis() with App.get_loop_component_star…

### DIFF
--- a/esphome/components/opentherm/hub.cpp
+++ b/esphome/components/opentherm/hub.cpp
@@ -1,4 +1,5 @@
 #include "hub.h"
+#include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 
 #include <string>
@@ -192,7 +193,7 @@ void OpenthermHub::loop() {
     return;
   }
 
-  auto cur_time = millis();
+  auto cur_time = App.get_loop_component_start_time();
   auto const cur_mode = this->opentherm_->get_mode();
 
   if (this->handle_error_(cur_mode)) {
@@ -249,7 +250,7 @@ void OpenthermHub::sync_loop_() {
     return;
   }
 
-  auto cur_time = millis();
+  auto cur_time = App.get_loop_component_start_time();
 
   this->check_timings_(cur_time);
 
@@ -337,7 +338,7 @@ void OpenthermHub::start_conversation_() {
   ESP_LOGD(TAG, "Sending request with id %d (%s)", request.id, message_id_to_str((MessageId) request.id));
   debug_data(request);
   // Send the request
-  this->last_conversation_start_ = millis();
+  this->last_conversation_start_ = App.get_loop_component_start_time();
   this->opentherm_->send(request);
 }
 
@@ -359,7 +360,7 @@ void OpenthermHub::read_response_() {
 
 void OpenthermHub::stop_opentherm_() {
   this->opentherm_->stop();
-  this->last_conversation_end_ = millis();
+  this->last_conversation_end_ = App.get_loop_component_start_time();
 }
 
 void OpenthermHub::handle_protocol_error_() {


### PR DESCRIPTION
…t_time()

According to the contribution guidelines this is preferred as millis() is relatively slow. These calls do not require super-accurate time so are easily replaced.

The two remaining calls to millis() in hub.h are for a spin wait implementation where time must increment on each call.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
