### PR TITLE
opentherm: miscellaneous fixes

### DIFF
--- a/esphome/components/opentherm/hub.h
+++ b/esphome/components/opentherm/hub.h
@@ -6,7 +6,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef USE_ESP32
 #include "opentherm_rmt.h"
 #endif
 #ifdef ESP8266

--- a/esphome/components/opentherm/opentherm_base.cpp
+++ b/esphome/components/opentherm/opentherm_base.cpp
@@ -1,7 +1,6 @@
 #include "opentherm_base.h"
 #include "esphome/core/helpers.h"
 #include <string>
-#include <esp_err.h>
 
 namespace esphome {
 namespace opentherm {

--- a/esphome/components/opentherm/opentherm_esp8266.cpp
+++ b/esphome/components/opentherm/opentherm_esp8266.cpp
@@ -58,6 +58,16 @@ void OpenTherm::log_protocol_state() const {
            to_string(clock_).c_str(), format_bin(this->capture_).c_str(), to_string(this->bit_pos_).c_str());
 }
 
+void IRAM_ATTR OpenTherm::read_() {
+  this->data_ = 0;
+  this->bit_pos_ = 0;
+  this->mode_ = OperationMode::READ;
+  this->capture_ = 1;         // reset counter and add as if read start bit
+  this->clock_ = 1;           // clock is high at the start of comm
+  this->start_read_timer_();  // get us into 1/4 of manchester code. 5 timer ticks constitute 1 ms, which is 1 bit
+                              // period in OpenTherm.
+}
+
 bool IRAM_ATTR OpenTherm::timer_isr(OpenTherm *arg) {
   if (arg->mode_ == OperationMode::LISTEN) {
     if (arg->timeout_counter_ == 0) {
@@ -85,7 +95,7 @@ bool IRAM_ATTR OpenTherm::timer_isr(OpenTherm *arg) {
         return false;
       } else if (arg->clock_ == 1 || arg->capture_ > 0xF) {
         // transition in the middle of the bit OR no transition between two bit, both are valid data points
-        if (arg->bit_pos_ == BitPositions::STOP_BIT) {
+        if (arg->bit_pos_ == 33) {
           // expecting stop bit
           auto stop_bit_error = arg->verify_stop_bit_(last);
           if (stop_bit_error == ProtocolErrorType::NO_ERROR) {
@@ -148,7 +158,7 @@ void IRAM_ATTR OpenTherm::bit_read_(uint8_t value) {
 
 ProtocolErrorType IRAM_ATTR OpenTherm::verify_stop_bit_(uint8_t value) {
   if (value) {  // stop bit detected
-    return check_parity_(this->data_) ? ProtocolErrorType::NO_ERROR : ProtocolErrorType::PARITY_ERROR;
+    return check_parity(this->data_) ? ProtocolErrorType::NO_ERROR : ProtocolErrorType::PARITY_ERROR;
   } else {  // no stop bit detected, error
     return ProtocolErrorType::INVALID_START_STOP_BIT;
   }

--- a/esphome/components/opentherm/opentherm_esp8266.h
+++ b/esphome/components/opentherm/opentherm_esp8266.h
@@ -43,7 +43,6 @@ class OpenTherm : public OpenThermBase {
   void read_();               // data detected start reading
   void start_read_timer_();   // reading timer_ to sample at 1/5 of manchester code bit length (at 5kHz)
   void start_write_timer_();  // writing timer_ to send manchester code (at 2kHz)
-  bool check_parity_(uint32_t val);
 
   void bit_read_(uint8_t value);
   ProtocolErrorType verify_stop_bit_(uint8_t value);

--- a/esphome/components/opentherm/opentherm_rmt.cpp
+++ b/esphome/components/opentherm/opentherm_rmt.cpp
@@ -12,7 +12,6 @@ namespace esphome {
 namespace opentherm {
 
 using std::string;
-using std::to_string;
 
 static const char *const TAG = "opentherm";
 

--- a/esphome/components/opentherm/opentherm_rmt.cpp
+++ b/esphome/components/opentherm/opentherm_rmt.cpp
@@ -154,33 +154,26 @@ void OpenTherm::rmt_read_() {
 void OpenTherm::rmt_write_() {
   // Build Manchester stream as raw RMT symbols, 1 bit = two halves of 500us
   rmt_symbol_word_t syms[34];
-  auto set_sym = [](rmt_symbol_word_t &s, bool level0, uint16_t dur0, bool level1, uint16_t dur1) {
-    s.level0 = level0;
-    s.duration0 = dur0;
-    s.level1 = level1;
-    s.duration1 = dur1;
-  };
 
   // Helper to encode a bit: 1 => low,high; 0 => high,low
-  auto encode_bit = [&](uint8_t bit) -> rmt_symbol_word_t {
+  auto encode_bit = [&](bool bit) -> rmt_symbol_word_t {
     rmt_symbol_word_t s{};
-    if (bit) {
-      set_sym(s, 0, 500, 1, 500);
-    } else {
-      set_sym(s, 1, 500, 0, 500);
-    }
+    s.level0 = bit ? 0 : 1;
+    s.duration0 = 500;
+    s.level1 = bit ? 1 : 0;
+    s.duration1 = 500;
     return s;
   };
 
   // Start bit '1'
-  syms[0] = encode_bit(1);
+  syms[0] = encode_bit(true);
   // Data bits MSB..LSB (bits 31..0)
   for (int i = 31; i >= 0; i--) {
     uint8_t b = (this->data_ >> i) & 0x1;
     syms[32 - i] = encode_bit(b);
   }
   // Stop bit '1'
-  syms[33] = encode_bit(1);
+  syms[33] = encode_bit(true);
 
   rmt_transmit_config_t cfg = {};
   cfg.loop_count = 0;

--- a/esphome/components/opentherm/opentherm_rmt.cpp
+++ b/esphome/components/opentherm/opentherm_rmt.cpp
@@ -1,4 +1,4 @@
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef USE_ESP32
 
 #include "opentherm_rmt.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/opentherm/opentherm_rmt.cpp
+++ b/esphome/components/opentherm/opentherm_rmt.cpp
@@ -258,7 +258,7 @@ bool IRAM_ATTR OpenTherm::decode_rmt_symbols_(size_t num_symbols) {
 
   auto produce_bit = [&](uint16_t level) -> uint8_t {
     if (prev_level == level) {
-      this->set_protocol_error(ProtocolErrorType::NO_TRANSITION);
+      this->set_protocol_error_(ProtocolErrorType::NO_TRANSITION);
       return ERROR_BIT_VALUE;
     }
 
@@ -279,10 +279,10 @@ bool IRAM_ATTR OpenTherm::decode_rmt_symbols_(size_t num_symbols) {
         tick = 1;
       } else {
         // Long intervals should happen only when we already have first half of a bit.
-        this->set_protocol_error(ProtocolErrorType::NO_CHANGE_TOO_LONG);
+        this->set_protocol_error_(ProtocolErrorType::NO_CHANGE_TOO_LONG);
       }
     } else {
-      this->set_protocol_error(ProtocolErrorType::INVALID_DURATION);
+      this->set_protocol_error_(ProtocolErrorType::INVALID_DURATION);
     }
 
     prev_level = level;
@@ -301,7 +301,7 @@ bool IRAM_ATTR OpenTherm::decode_rmt_symbols_(size_t num_symbols) {
         if (level == 0 && prev_level == 1) {
           bit = 1;
         } else {
-          this->set_protocol_error(ProtocolErrorType::INVALID_START_STOP_BIT);
+          this->set_protocol_error_(ProtocolErrorType::INVALID_START_STOP_BIT);
           return false;
         }
       } else {
@@ -317,7 +317,7 @@ bool IRAM_ATTR OpenTherm::decode_rmt_symbols_(size_t num_symbols) {
 
       if (this->bit_index_ == 0 || this->bit_index_ == 33) {  // Check start and stop bit
         if (bit != 1) {
-          this->set_protocol_error(ProtocolErrorType::INVALID_START_STOP_BIT);
+          this->set_protocol_error_(ProtocolErrorType::INVALID_START_STOP_BIT);
           return false;
         }
       } else {
@@ -332,11 +332,11 @@ bool IRAM_ATTR OpenTherm::decode_rmt_symbols_(size_t num_symbols) {
   }
 
   // If we reached here, something went wrong and our data is incomplete.
-  this->set_protocol_error(ProtocolErrorType::INSUFFICIENT_DATA);
+  this->set_protocol_error_(ProtocolErrorType::INSUFFICIENT_DATA);
   return false;
 }
 
-void OpenTherm::set_protocol_error(ProtocolErrorType error_type) {
+void OpenTherm::set_protocol_error_(ProtocolErrorType error_type) {
   this->mode_ = OperationMode::ERROR_PROTOCOL;
   this->error_type_ = error_type;
 }

--- a/esphome/components/opentherm/opentherm_rmt.h
+++ b/esphome/components/opentherm/opentherm_rmt.h
@@ -54,7 +54,7 @@ class OpenTherm : public OpenThermBase {
   void rmt_write_();
   static bool rmt_read_callback(rmt_channel_handle_t channel, const rmt_rx_done_event_data_t *evt, void *arg);
 
-  void set_protocol_error(ProtocolErrorType error_type);
+  void set_protocol_error_(ProtocolErrorType error_type);
 
   bool decode_rmt_symbols_(size_t num_symbols);
 };

--- a/esphome/components/opentherm/opentherm_rmt.h
+++ b/esphome/components/opentherm/opentherm_rmt.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef USE_ESP32
 
 #include <string>
 #include "opentherm_base.h"


### PR DESCRIPTION
# What does this implement/fix?

This makes the `opentherm-dev` branch pass CI with a clean bill of health. Fixes compilation on ESP8266 and cleans up clang-tidy warnings / nitpicks.

Only compile-tested so far.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
